### PR TITLE
Fixed a rounding bug with sliders and :grid

### DIFF
--- a/components/slider.lisp
+++ b/components/slider.lisp
@@ -34,8 +34,8 @@
 (defmethod (setf value) :around (value (slider slider))
   (destructuring-bind (min . max) (range slider)
     (let ((value (if (< 0 (grid slider))
-		     (+ min (* (round (- value min) (grid slider)) (grid slider)))
-		     value)))
+                     (+ min (* (round (- value min) (grid slider)) (grid slider)))
+                     value)))
       (call-next-method (max min (min max value)) slider))))
 
 (defmethod (setf value) :after (value (slider slider))

--- a/components/slider.lisp
+++ b/components/slider.lisp
@@ -32,10 +32,10 @@
         (max 0 (min 1 (/ (- (value slider) min) (- max min)))))))
 
 (defmethod (setf value) :around (value (slider slider))
-  (let ((value (if (< 0 (grid slider))
-                   (* (round (/ value (grid slider))) (grid slider))
-                   value)))
-    (destructuring-bind (min . max) (range slider)
+  (destructuring-bind (min . max) (range slider)
+    (let ((value (if (< 0 (grid slider))
+		     (+ min (* (round (- value min) (grid slider)) (grid slider)))
+		     value)))
       (call-next-method (max min (min max value)) slider))))
 
 (defmethod (setf value) :after (value (slider slider))


### PR DESCRIPTION
It's a one line fix, but it's honest work I suppose.

I head the problem that, when I created a slider like this:
```
(slider (alloy:represent value 'alloy:ranged-slider :range '(1 . 9) :grid 2))
```
I would get the following intervals: 1, 2, 4, 6, 8, 9.
With this change it should now be: 1, 3, 5, 7, 9.

The whole test I've ran to debug is this (I've naturally ran this in examples/windows.lisp):
```
(define-example slider (screen)
  (let* ((window (windowing:make-window screen))
	 (focus (make-instance 'alloy:focus-list :focus-parent window))
	 (layout (make-instance 'alloy:vertical-linear-layout :layout-parent window))
	 (value 1)
	 (value-two 0)
	 (slider (alloy:represent value 'alloy:ranged-slider :range '(1 . 9) :grid 2))
	 (slider-two (alloy:represent value-two 'alloy:ranged-slider :range '(0 . 10))))
    (alloy:enter slider layout)
    (alloy:enter slider-two layout)
    (alloy:enter slider focus)
    (alloy:enter slider-two focus)))
```