### PR TITLE
Missing dependencies

### DIFF
--- a/test/alloy-test.asd
+++ b/test/alloy-test.asd
@@ -17,5 +17,6 @@
                (:file "focus-tree")
                (:file "geometry"))
   :depends-on (:alloy
+               :alexandria
                :parachute)
   :perform (asdf:test-op (op c) (uiop:symbol-call :parachute :test :org.shirakumo.alloy.test)))


### PR DESCRIPTION
Test https://github.com/Shirakumo/alloy/blob/bb4d114acdc59c7835e490607a0b25032223c806/test/focus-tree.lisp#L79 requires `alexandria` library.