### PR TITLE
GLFW adjustments

### DIFF
--- a/renderers/glfw/fixup.lisp
+++ b/renderers/glfw/fixup.lisp
@@ -71,4 +71,5 @@
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (setf (gethash ,key (cffi::keyword-values (cffi::ensure-parsed-base-type ,enum))) ,value)))
 
+(add-enum-value '%glfw:window-hint :floating #X00020007)
 (add-enum-value '%glfw:window-hint :maximized #X00020008)

--- a/renderers/glfw/fixup.lisp
+++ b/renderers/glfw/fixup.lisp
@@ -63,3 +63,12 @@
 (cffi:defcfun (%glfw::get-key-name "glfwGetKeyName") :string
   (key %glfw::key)
   (scan-code :int))
+
+
+(defmacro add-enum-value (enum key value)
+  "Pushes a key/value pair into a cffi enum. Abuses cffi internals.
+   This will work only for enums containing only keywords."
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (setf (gethash ,key (cffi::keyword-values (cffi::ensure-parsed-base-type ,enum))) ,value)))
+
+(add-enum-value '%glfw:window-hint :maximized #X00020008)

--- a/renderers/glfw/renderer.lisp
+++ b/renderers/glfw/renderer.lisp
@@ -10,7 +10,7 @@
   ((parent :initarg :parent :accessor parent)
    (pointer :accessor pointer)))
 
-(defmethod initialize-instance :after ((renderer renderer) &key title (size (alloy:px-size 1 1)) visible-p decorated-p)
+(defmethod initialize-instance :after ((renderer renderer) &key title (size (alloy:px-size 1 1)) visible-p decorated-p (resizable-p t))
   (let ((glfw:*window* NIL))
     (%glfw:make-context-current (cffi:null-pointer))
     (float-features:with-float-traps-masked T
@@ -20,6 +20,7 @@
        :title (or title "")
        :visible visible-p
        :decorated decorated-p
+       :resizable resizable-p
        :opengl-forward-compat T
        :opengl-profile :opengl-core-profile
        :context-version-major 3

--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -128,6 +128,7 @@
                                                     (icon window:*default-window-icon*)
                                                     (bounds window:*default-window-bounds*)
                                                     (decorated-p T) (state :normal)
+			                            (resizable-p T)
                                                     (background-color colors:black)
                                                     (class 'window)
                                                     min-size max-size always-on-top-p
@@ -138,6 +139,7 @@
                                       :title title
                                       :size bounds
                                       :decorated-p decorated-p
+				      :resizable-p resizable-p
                                       :background-color background-color))
          (pointer (pointer window)))
     (when (typep bounds 'alloy:extent)

--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -55,8 +55,8 @@
   ((pointer :initarg :pointer :initform (alloy:arg! :pointer) :reader pointer)))
 
 (defmethod window:size ((monitor monitor))
-  (destructuring-bind (&key width height &allow-other-keys) (glfw:get-video-mode (pointer monitor))
-    (alloy:px-size width height)))
+  (let* ((vid-mode (glfw:get-video-mode (pointer monitor))))
+    (alloy:px-size (getf vid-mode '%cl-glfw3:width) (getf vid-mode '%cl-glfw3:height))))
 
 (defclass screen (window:screen renderer
                   org.shirakumo.alloy.renderers.simple.presentations::default-look-and-feel)

--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -58,6 +58,10 @@
   (let* ((vid-mode (glfw:get-video-mode (pointer monitor))))
     (alloy:px-size (getf vid-mode '%cl-glfw3:width) (getf vid-mode '%cl-glfw3:height))))
 
+(defmethod window:location ((monitor monitor))
+  (destructuring-bind (x y) (glfw:get-monitor-position (pointer monitor))
+    (alloy:px-point x y)))
+
 (defclass screen (window:screen renderer
                   org.shirakumo.alloy.renderers.simple.presentations::default-look-and-feel)
   ())
@@ -210,6 +214,11 @@
   (destructuring-bind (w h) (%glfw:get-window-size (pointer window))
     (unless (and (= w (alloy:pxw size)) (= h (alloy:pxh size)))
       (%glfw:set-window-size (pointer window) (max 1 (round (alloy:pxw size))) (max 1 (round (alloy:pxh size)))))))
+
+(defmethod (setf alloy:location) :after (location (window window))
+  (destructuring-bind (x y) (%glfw:get-window-position (pointer window))
+    (unless (and (= x (alloy:pxx location)) (= y (alloy:pxy location)))
+      (%glfw:set-window-position (pointer window) (round (alloy:pxx location)) (round (alloy:pxy location))))))
 
 (defmethod (setf alloy:bounds) :after (extent (window window))
   (let ((target (simple:transform-matrix window)))

--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -292,10 +292,10 @@
   (%glfw::set-window-icon (pointer window) 0 (cffi:null-pointer)))
 
 (defmethod window:always-on-top-p ((window window))
-  (get-window-bool-attribute window #x00020007))
+  (get-window-bool-attribute window :floating))
 
 (defmethod (setf window:always-on-top-p) (top (window window))
-  (%glfw::set-window-attrib (pointer window) #x00020007 top)
+  (%glfw::set-window-attrib (pointer window) :floating top)
   top)
 
 (defmethod window:fullscreen ((window window) monitor)

--- a/windowing/package.lisp
+++ b/windowing/package.lisp
@@ -15,6 +15,7 @@
    #:list-windows
    #:list-monitors
    #:size
+   #:location
    #:window
    #:layout-element
    #:focus-element

--- a/windowing/protocol.lisp
+++ b/windowing/protocol.lisp
@@ -25,6 +25,7 @@
 (defgeneric list-monitors (screen))
 (defgeneric list-windows (screen))
 (defgeneric size (monitor/screen))
+(defgeneric location (monitor/screen))
 
 (defclass window (alloy:layout-element alloy:focus-element alloy:renderable alloy:observable)
   ((layout-element :initform NIL :accessor layout-element)


### PR DESCRIPTION
To add some background - what i'm currently working on is a dock application (along the lines of dmenu/rofi)

For this i was missing the ability to set the location of the window as well as the ability to force it to not be resizeable (forces my WM to treat it as a dock/tooltip window)

Apart from that i added a way to force CFFI values. The eval-when coincides with the ffi code that does the initial enum construction. This was necessary for :maximized - as its absence was causing some crashes.
(Honestly it feels like it might make more sense to just use a different glfw wrapper, or to fork/update the existing one)

window:size method was trying and failing to destructure the cffi video-mode list - which contained namespaced symbols.
(Could not find a way to destructure using namespaced keys).

==================================================

If i may, i've also got one commit on the side, which i'm constantly using but am not too happy about, and would like to get an onion on.
I started playing around with desktop programs in CL a short while ago, and one of the things i came upon was the usage of the livesupport package.
With it - it's usually possible to add it at some point in a render loop and make the repl responsive, giving some more debugging capabilities.
As an example:
```common-lisp
(defun frame (win)
  (livesupport:update-repl-link)
  (draw)
  (sleep 16))
```

I'm forcing it in here like so - but I don't like the extra argument:
https://github.com/bmiww/alloy/commit/de82507601f0283b2ba009688eed631192579fc7

Am i maybe missing something else that could be used from alloy or in general that wouldn't require any code change for that kind of a thing?