### PR TITLE
Minor fixes

### DIFF
--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -317,7 +317,7 @@
                                 :dx x
                                 :location (cursor-location window))))
 
-(defmethod glfw:char-entered ((window window) char mods)
+(defmethod glfw:char-entered ((window window) char)
   (handle window (make-instance 'alloy:text-event :text (string char))))
 
 (defmethod glfw:mouse-entered ((window window) entered)

--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -318,7 +318,7 @@
                                 :location (cursor-location window))))
 
 (defmethod glfw:char-entered ((window window) char)
-  (handle window (make-instance 'alloy:text-event :text (string char))))
+  (handle window (make-instance 'alloy:text-event :text (string (code-char char)))))
 
 (defmethod glfw:mouse-entered ((window window) entered)
   (if entered

--- a/renderers/glfw/windowing.lisp
+++ b/renderers/glfw/windowing.lisp
@@ -45,11 +45,11 @@
     (set-icon icon cursor)))
 
 (defmethod window:size ((monitor glfw:monitor))
-  (let ((size (glfw:size (pointer monitor))))
+  (let ((size (glfw:size monitor)))
     (alloy:px-size (first size) (second size))))
 
 (defmethod window:location ((monitor glfw:monitor))
-  (let ((location (glfw:location (pointer monitor))))
+  (let ((location (glfw:location monitor)))
     (alloy:px-point (first location) (second location))))
 
 (defclass screen (window:screen renderer


### PR DESCRIPTION
Got a couple more fixes ready.

Managed to get My own project to mostly do what it did before.

Still have a somewhat weird situation when i'm running:
`(alloy:suggest-size (alloy:px-size 0 0) *window*)`
It seems to completely crash sbcl, making it a bit more involved to find the issue.
Running:
`(alloy:suggest-size (alloy:px-size 1 1) *window*)`
seems ok.


Fixes i've included:
Some leftover unneeded pointer extraction.
Character input was missing code-charring

One that is slightly more onionated - leave it up to you:
The character+mod input callback from glfw is deprecated, thought i'd move it to the one without "+mod".
Related MR from glfw lib side:
https://github.com/Shirakumo/glfw/pull/2
