### PR TITLE
Examples on data classes. remap-data. Extending accessor-data.

### DIFF
--- a/components/combo.lisp
+++ b/components/combo.lisp
@@ -3,6 +3,9 @@
 (defclass combo-item (button direct-value-component)
   ())
 
+(defclass combo-item* (combo-item)
+  ((text :initarg :text :initform NIL :accessor text)))
+
 (defclass combo-layout (vertical-linear-layout)
   ((parent :initarg :parent :accessor parent)))
 
@@ -190,3 +193,6 @@
 
 (defmethod (setf value-set) :after (set (combo combo-set))
   (update-combo-items combo set))
+
+(defmethod combo-item ((item cons) (combo combo-set))
+  (make-instance 'combo-item* :value (car item) :text (cdr item)))

--- a/components/combo.lisp
+++ b/components/combo.lisp
@@ -65,7 +65,10 @@
 (defmethod text ((combo combo))
   (if (focused combo)
       (text (focused combo))
-      (princ-to-string (value combo))))
+      (let ((value (value combo)))
+        (do-elements (element combo :result (princ-to-string value))
+          (when (eql value (value element))
+            (return (text element)))))))
 
 (defmethod notice-size ((list combo-layout) (combo combo))
   (notice-size combo T))

--- a/data.lisp
+++ b/data.lisp
@@ -113,29 +113,29 @@
   (unless (slot-boundp data 'mapping) (return-from c2mop:slot-value-using-class (call-next-method)))
   (let ((mapped (gethash (c2mop:slot-definition-name slot) (mapping data))))
     (if mapped
-	(setf (slot-value (object data) mapped) value)
-	(call-next-method))))
+        (setf (slot-value (object data) mapped) value)
+        (call-next-method))))
 
 (defmethod access ((data remap-data) field)
   (let ((mapped (gethash field (mapping data))))
     (if mapped
-       (access (object data) mapped)
-       (slot-value data field))))
+        (access (object data) mapped)
+        (slot-value data field))))
 
 (defmethod (setf access) (value (data remap-data) field)
   (let ((mapped (gethash field (mapping data))))
     (if mapped
-       (setf (access (object data) mapped) value)
-       (setf (slot-value data field) value))))
+        (setf (access (object data) mapped) value)
+        (setf (slot-value data field) value))))
 
 (defmethod observe ((nothing (eql NIL)) object (data remap-data) &optional (name data))
   (loop for mapped being the hash-value of (mapping data)
-	do (remove-observers mapped object name)))
+        do (remove-observers mapped object name)))
 
 (defmethod observe ((all (eql T)) object (data remap-data) &optional (name data))
   (loop for function being the hash-keys of (mapping data) using (hash-value mapped)
         do (let ((mapped mapped) (function function))
-	     (observe mapped object (lambda (&rest args) (apply #'notify-observers function data args)) name)))
+             (observe mapped object (lambda (&rest args) (apply #'notify-observers function data args)) name)))
   (refresh data))
 
 (defmethod refresh ((data remap-data))
@@ -177,8 +177,8 @@
 (defmethod initialize-instance :after ((data accessor-data) &key)
   (when (typep (object data) 'observable-object)
     (let* ((generic (c2mop:ensure-generic-function (accessor data)))
-	   (method (car (c2mop:generic-function-methods generic)))
-	   (slot (c2mop:accessor-method-slot-definition method)))
+           (method (car (c2mop:generic-function-methods generic)))
+           (slot (c2mop:accessor-method-slot-definition method)))
       (observe (c2mop:slot-definition-name slot) (object data) (lambda (value object) (notify-observers 'value data value object)) data)))
 
   (when (typep (object data) 'observable)

--- a/data.lisp
+++ b/data.lisp
@@ -110,8 +110,8 @@
     (setf (mapping data) table)))
 
 (defmethod (setf c2mop:slot-value-using-class) :around (value class (data remap-data) slot)
-  (unless (slot-boundp data 'mapping) (return-from c2mop:slot-value-using-class (call-next-method)))
-  (let ((mapped (gethash (c2mop:slot-definition-name slot) (mapping data))))
+  (let ((mapped (when (slot-boundp data 'mapping)
+                  (gethash (c2mop:slot-definition-name slot) (mapping data)))))
     (if mapped
         (setf (slot-value (object data) mapped) value)
         (call-next-method))))

--- a/data.lisp
+++ b/data.lisp
@@ -109,6 +109,13 @@
   (let ((table (make-hash-table :test 'eql)))
     (setf (mapping data) table)))
 
+(defmethod (setf c2mop:slot-value-using-class) :around (value class (data remap-data) slot)
+  (unless (slot-boundp data 'mapping) (return-from c2mop:slot-value-using-class (call-next-method)))
+  (let ((mapped (gethash (c2mop:slot-definition-name slot) (mapping data))))
+    (if mapped
+	(setf (slot-value (object data) mapped) value)
+	(call-next-method))))
+
 (defmethod access ((data remap-data) field)
   (let ((mapped (gethash field (mapping data))))
     (if mapped

--- a/data.lisp
+++ b/data.lisp
@@ -110,11 +110,11 @@
     (setf (mapping data) table)))
 
 (defmethod observe ((nothing (eql NIL)) object (data remap-data) &optional (name data))
-  (loop for function being the hash-keys of (observed data)
+  (loop for function being the hash-keys of (mapping data)
         do (remove-observers function object name)))
 
 (defmethod observe ((all (eql T)) object (data remap-data) &optional (name data))
-  (loop for function being the hash-keys of (observed data) using (hash-value mapped)
+  (loop for function being the hash-keys of (mapping data) using (hash-value mapped)
         do (observe function object (lambda (&rest args) (apply #'notify-observers mapped data args)) name))
   (refresh data))
 

--- a/data.lisp
+++ b/data.lisp
@@ -155,6 +155,12 @@
   ((accessor :initarg :accessor :initform (arg! :accessor) :accessor accessor)))
 
 (defmethod initialize-instance :after ((data accessor-data) &key)
+  (when (typep (object data) 'observable-object)
+    (let* ((generic (c2mop:ensure-generic-function (accessor data)))
+	   (method (car (c2mop:generic-function-methods generic)))
+	   (slot (c2mop:accessor-method-slot-definition method)))
+      (observe (c2mop:slot-definition-name slot) (object data) (lambda (value object) (notify-observers 'value data value object)) data)))
+
   (when (typep (object data) 'observable)
     (observe (accessor data) (object data) (lambda (value object) (notify-observers 'value data value object)) data)))
 

--- a/examples/alloy-examples.asd
+++ b/examples/alloy-examples.asd
@@ -16,6 +16,7 @@
                (:file "font-mixing")
                (:file "fonts")
                (:file "canvas")
-	       (:file "gradient"))
+	       (:file "gradient")
+	       (:file "data"))
   :depends-on (:alloy-glfw
                :alloy-constraint))

--- a/examples/data.lisp
+++ b/examples/data.lisp
@@ -1,0 +1,89 @@
+(in-package #:org.shirakumo.alloy.examples)
+
+(defclass example-object (alloy:observable-object)
+  ((foo :initform "foo")
+   (bar :initform "bar" :accessor bar-accessor)))
+
+(defclass another-object (alloy:observable-object alloy:remap-data)
+  ((far) (boo :accessor boo-accessor)
+   (unique :initform "unique")))
+
+(define-example data (screen)
+  (let* ((window      (windowing:make-window screen))
+	 (object      (make-instance 'example-object))
+	 (object-data (make-instance 'alloy:object-data :object object))
+         (layout     (make-instance 'alloy:vertical-linear-layout :layout-parent window))
+         (focus      (make-instance 'alloy:focus-list :focus-parent window))
+	 (refresh    (alloy:represent "Refresh" 'alloy:button :layout-parent layout :focus-parent focus))
+	 (adjust-1   (alloy:represent "(slot-value object 'bar)" 'alloy:button))
+	 (adjust-2   (alloy:represent "(slot-value object 'foo)" 'alloy:button)))
+
+    (alloy:on alloy:activate (refresh) (alloy:refresh layout))
+    (alloy:on alloy:activate (adjust-1) (setf (slot-value object 'bar) (randobar)))
+    (alloy:on alloy:activate (adjust-2) (setf (slot-value object 'foo) (randofoo)))
+
+    (enter+ adjust-1 adjust-2 layout)
+    (enter+ adjust-1 adjust-2 focus)
+
+    ;; Shows an interaction with the accessor-data class
+    (let* ((layout            (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
+	   (bar-accessor-data (make-instance 'alloy:accessor-data :accessor 'bar-accessor :object object))
+	   (label             (make-instance 'alloy:label :data bar-accessor-data))
+	   (button            (alloy:represent "(alloy:value bar-accessor-data)" 'alloy:button)))
+      (alloy:on alloy:activate (button) (setf (alloy:value bar-accessor-data) (randobar)))
+      (enter+ button label layout)
+      (enter+ button focus))
+
+    ;; Shows an interaction with the slot-data class
+    (let* ((layout        (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
+	   (foo-slot-data (make-instance 'alloy:slot-data :slot 'foo :object object))
+	   (label         (make-instance 'alloy:label :data foo-slot-data))
+	   (button        (alloy:represent "(alloy:value foo-slot-data)" 'alloy:button)))
+      (alloy:on alloy:activate (button) (setf (alloy:value foo-slot-data) (randofoo)))
+      (enter+ button label layout)
+      (enter+ button focus))
+
+    ;; Object-data but label is accessing the bar field of the object
+    (let* ((layout (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
+	   (label  (make-instance 'alloy:label :data object-data :value-function 'bar))
+	   (button (alloy:represent "(access object-data 'bar)" 'alloy:button)))
+      (alloy:on alloy:activate (button) (setf (alloy:access object-data 'bar) (randobar)))
+      (enter+ button label layout)
+      (enter+ button focus))
+
+    ;; Object-data but label is accessing the foo field of the object
+    (let* ((layout (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
+	   (label  (make-instance 'alloy:label :data object-data :value-function 'foo))
+	   (button (alloy:represent "(access object-data 'foo)" 'alloy:button)))
+      (alloy:on alloy:activate (button) (setf (alloy:access object-data 'foo) (randofoo)))
+      (enter+ button label layout)
+      (enter+ button focus))
+
+    ;; Attaches observers that will print out the observation
+    ;; e.g: (alloy:observe 'bar object-data (lambda (value data) (print "Observation")))
+    (loop for (observation observable) in `((foo ,object) (bar ,object) (foo ,object-data) (bar ,object-data))
+	  do (let ((observation observation) (observable observable))
+	       (alloy:observe observation observable
+			      (lambda (value data)
+				(declare (ignore value data))
+				(format t "Observed a change for ~a in ~a~%" observation observable)))))))
+
+
+
+(presentations:define-update (presentations:default-look-and-feel alloy:button)
+  (:label :text alloy:text
+   :halign :start
+   :size 10))
+
+(presentations:define-update (presentations:default-look-and-feel alloy:label)
+  (:label :text alloy:text
+   :halign :start
+   :size 10))
+
+
+;; Convenience utilities
+(defun randofoo () (format nil "foo-~a" (random 1000)))
+(defun randobar () (format nil "bar-~a" (random 1000)))
+(defun randofar () (format nil "far-~a" (random 1000)))
+(defun randoboo () (format nil "boo-~a" (random 1000)))
+(defun randounique () (format nil "unique-~a" (random 1000)))

--- a/examples/data.lisp
+++ b/examples/data.lisp
@@ -117,3 +117,9 @@
 (defun randofar () (format nil "far-~a" (random 1000)))
 (defun randoboo () (format nil "boo-~a" (random 1000)))
 (defun randounique () (format nil "unique-~a" (random 1000)))
+
+(defun mk-hash-table (&rest args)
+  (let ((table (make-hash-table :test 'eql)))
+    (loop for (key value) on args by #'cddr
+	  collect (setf (gethash key table) value))
+    table))

--- a/examples/data.lisp
+++ b/examples/data.lisp
@@ -24,8 +24,8 @@
     (alloy:on alloy:activate (adjust-1) (setf (slot-value object 'bar) (randobar)))
     (alloy:on alloy:activate (adjust-2) (setf (slot-value object 'foo) (randofoo)))
 
-    (enter+ adjust-1 adjust-2 layout)
-    (enter+ adjust-1 adjust-2 focus)
+    (alloy:enter-all layout adjust-1 adjust-2)
+    (alloy:enter-all focus adjust-1 adjust-2)
 
     ;; Shows an interaction with the accessor-data class
     (let* ((layout            (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
@@ -33,8 +33,8 @@
 	   (label             (make-instance 'alloy:label :data bar-accessor-data))
 	   (button            (alloy:represent "(alloy:value bar-accessor-data)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:value bar-accessor-data) (randobar)))
-      (enter+ button label layout)
-      (enter+ button focus))
+      (alloy:enter-all layout button label)
+      (alloy:enter-all focus button))
 
     ;; Shows an interaction with the slot-data class
     (let* ((layout        (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
@@ -42,24 +42,24 @@
 	   (label         (make-instance 'alloy:label :data foo-slot-data))
 	   (button        (alloy:represent "(alloy:value foo-slot-data)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:value foo-slot-data) (randofoo)))
-      (enter+ button label layout)
-      (enter+ button focus))
+      (alloy:enter-all layout button label)
+      (alloy:enter-all focus button))
 
     ;; Object-data but label is accessing the bar field of the object
     (let* ((layout (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
 	   (label  (make-instance 'alloy:label :data object-data :value-function 'bar))
 	   (button (alloy:represent "(access object-data 'bar)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:access object-data 'bar) (randobar)))
-      (enter+ button label layout)
-      (enter+ button focus))
+      (alloy:enter-all layout button label)
+      (alloy:enter-all focus button))
 
     ;; Object-data but label is accessing the foo field of the object
     (let* ((layout (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
 	   (label  (make-instance 'alloy:label :data object-data :value-function 'foo))
 	   (button (alloy:represent "(access object-data 'foo)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:access object-data 'foo) (randofoo)))
-      (enter+ button label layout)
-      (enter+ button focus))
+      (alloy:enter-all layout button label)
+      (alloy:enter-all focus button))
 
     ;; Using an object with remapped-data targeting boo->bar
     (let* ((layout   (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
@@ -68,8 +68,8 @@
 	   (button-2 (alloy:represent "(slot-value remap-data 'boo)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:access remap-data 'boo) (randoboo)))
       (alloy:on alloy:activate (button-2) (setf (slot-value remap-data 'boo) (randoboo)))
-      (enter+ button button-2 label layout)
-      (enter+ button button-2 focus))
+      (alloy:enter-all layout button button-2 label)
+      (alloy:enter-all focus button button-2 ))
 
     ;; Using an object with remapped-data targeting far-foo
     (let* ((layout   (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
@@ -78,16 +78,16 @@
 	   (button-2 (alloy:represent "(slot-value remap-data 'far)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:access remap-data 'far) (randofar)))
       (alloy:on alloy:activate (button-2) (setf (slot-value remap-data 'far) (randofar)))
-      (enter+ button button-2 label layout)
-      (enter+ button button-2 focus))
+      (alloy:enter-all layout button button-2 label)
+      (alloy:enter-all focus button button-2))
 
     ;; Using remap-data but with a slot that is not mapped
     (let* ((layout (make-instance 'alloy:horizontal-linear-layout :layout-parent layout))
 	   (label  (make-instance 'alloy:label :data remap-data :value-function 'unique))
 	   (button (alloy:represent "(alloy:access remap-data 'unique)" 'alloy:button)))
       (alloy:on alloy:activate (button) (setf (alloy:access remap-data 'unique) (randounique)))
-      (enter+ button label layout)
-      (enter+ button focus))
+      (alloy:enter-all layout button label)
+      (alloy:enter-all focus button))
 
     ;; Attaches observers that will print out the observation
     ;; e.g: (alloy:observe 'boo remap-data (lambda (value data) (print "Observation")))

--- a/examples/toolkit.lisp
+++ b/examples/toolkit.lisp
@@ -19,20 +19,3 @@
                     (glfw:with-screen (*screen* 'screen :base-scale 2.0)
                       (,thunk *screen*)))))
             (pushnew ',name *examples*))))
-
-
-(defun butwithlast (list)
-  (let* ((last)
-	 (beginning
-	   (loop for item in list
-		 for index from 0
-		 when (eq index (- (length list) 1)) do (setf last item) until last
-		 collect item)))
-    (values beginning last)))
-
-(defmacro mk-hash-table (&rest args)
-  (let ((table (gensym)))
-    `(let ((,table (make-hash-table :test 'eql)))
-       ,@(loop for (key value) on args by #'cddr
-	       collect `(setf (gethash ,key ,table) ,value))
-       ,table)))

--- a/examples/toolkit.lisp
+++ b/examples/toolkit.lisp
@@ -19,3 +19,26 @@
                     (glfw:with-screen (*screen* 'screen :base-scale 2.0)
                       (,thunk *screen*)))))
             (pushnew ',name *examples*))))
+
+
+(defun butwithlast (list)
+  (let* ((last)
+	 (beginning
+	   (loop for item in list
+		 for index from 0
+		 when (eq index (- (length list) 1)) do (setf last item) until last
+		 collect item)))
+    (values beginning last)))
+
+(defmacro enter+ (&rest args)
+  (multiple-value-bind (elements container) (butwithlast args)
+    `(progn
+       ,@(loop for element in elements
+	       collect `(alloy:enter ,element ,container)))))
+
+(defmacro mk-hash-table (&rest args)
+  (let ((table (gensym)))
+    `(let ((,table (make-hash-table :test 'eql)))
+       ,@(loop for (key value) on args by #'cddr
+	       collect `(setf (gethash ,key ,table) ,value))
+       ,table)))

--- a/examples/toolkit.lisp
+++ b/examples/toolkit.lisp
@@ -30,12 +30,6 @@
 		 collect item)))
     (values beginning last)))
 
-(defmacro enter+ (&rest args)
-  (multiple-value-bind (elements container) (butwithlast args)
-    `(progn
-       ,@(loop for element in elements
-	       collect `(alloy:enter ,element ,container)))))
-
 (defmacro mk-hash-table (&rest args)
   (let ((table (gensym)))
     `(let ((,table (make-hash-table :test 'eql)))


### PR DESCRIPTION
Hey!

Dropping here some musings i've had while exploring the alloy data classes.
Since the existing examples helped me get going - thought i'd write my own for the data classes while i was playing around with them.
It's not a complete example on all the possible data classes - but it covers some of the points of interest i had.
Namely - several of the data classes that inherit from object-data.

Which also got me going on playing around with the implementations of some of the data classes.
The FEAT commits are as follows:

- accessor-data: I rather liked the idea of derived observations - where an accessor observation would be notified also when the slot connected to the accessor changes.
- remap-data: Making some assumptions about the intended use here - but i assume this is meant as an object which proxies slots to a base object. Therefore - I've fixed the observe invocations and extended the access methods to consider mapping declarations.
- remap-data setf slot-value: This one i'm not fully sure of. It covers the case when a slot on the remap-data object would be changed directly - if its a mapped slot - similar behaviour to how access methods are handled.

While writing the example - it irred me that whenever i would change the base object values directly - the observers of accessor-data or remap-data wouldn't fire - which ended up being my motivation for all this.