### PR TITLE
Typo in define-expression-transform :strong

### DIFF
--- a/layouts/constraint/constraints.lisp
+++ b/layouts/constraint/constraints.lisp
@@ -80,7 +80,7 @@
   (values
    (loop for expression in expressions
          append (transform-expression expression))
-   :medium))
+   :strong))
 
 (define-expression-transform :required (&rest expressions)
   (values


### PR DESCRIPTION
Was using `:medium` instead of `:strong`.