### PR TITLE
Support LispWorks

### DIFF
--- a/widget.lisp
+++ b/widget.lisp
@@ -17,10 +17,11 @@
 (defgeneric add-initializer (name class &key priority function if-exists))
 (defgeneric remove-initializer (name class))
 
-(defmethod c2mop:validate-superclass ((a widget-class) (b T)) NIL)
-(defmethod c2mop:validate-superclass ((a widget-class) (b standard-class)) T)
-(defmethod c2mop:validate-superclass ((a widget-class) (b widget-class)) T)
-(defmethod c2mop:validate-superclass ((a standard-class) (b widget-class)) NIL)
+(#-lispworks progn #+lispworks eval-when #+lispworks (:compile-toplevel :load-toplevel :execute)
+  (defmethod c2mop:validate-superclass ((a widget-class) (b T)) NIL)
+  (defmethod c2mop:validate-superclass ((a widget-class) (b standard-class)) T)
+  (defmethod c2mop:validate-superclass ((a widget-class) (b widget-class)) T)
+  (defmethod c2mop:validate-superclass ((a standard-class) (b widget-class)) NIL))
 
 (defclass direct-initializer-slot (c2mop:standard-direct-slot-definition)
   ((usage :initarg :usage :initform NIL :accessor usage)
@@ -34,7 +35,7 @@
                                          (declare (ignorable widget))
                                          (list ',type ,@initargs))))))
 
-(defmethod c2mop:direct-slot-definition-class ((class widget-class) &key initializer representation)
+(defmethod c2mop:direct-slot-definition-class ((class widget-class) &key initializer representation &allow-other-keys)
   (if (or representation initializer)
       (find-class 'direct-initializer-slot)
       (call-next-method)))


### PR DESCRIPTION
This commit fix 3 problems that block Alloy from running on Lispworks. Tested LispWorks 8.0.1 Macintosh with Apple M3, macOS Sequoia 15.3.1, using the `simple-window` example, and multiprocessing disabled. It can still be successfully compiled with SBCL after changes.

In `widget.lisp`:

- Wrapping `validate-superclass` with `eval-when` in all cases. Or the `validate-superclass` will not effective when defining `widget` and raise an invalid superclass error during the first try of compile.

- For unknown reason, user defined methods on `direct-slot-definition-class` will not be called when (re)initializing instance, and the new method cannot call the default one using `call-next-method`, at least for `widget-class`. The default method will raise an error during `shared-initialize` saying it is called with invalid initargs. So we added a method to the LW special generic function `compute-effective-method-function-from-classes` [suggested by LW manual](https://www.lispworks.com/documentation/lw80/lw/lw-mop-ug-2.htm) to manually dispatch general function call, and finding default method manually in `direct-slot-definition-class`.

In `unmanaged.lisp`:

- `cffi:with-pointer-to-vector-data` simply use `fli:with-dynamic-lisp-array-pointer` on Lispworks, which is a macro that only accepts arrays which explicitly declared as "static or pinned" using the LW special keyword argument `:allocation` of `make-array`. So we added a copying to produce valid array. Perhaps it should be handled by CFFI though...
